### PR TITLE
Fixed Super Sonic jump panel (stuck and miss) + Wrong texture and physics on P.C boss

### DIFF
--- a/sadx-super-sonic/advanced-mode.cpp
+++ b/sadx-super-sonic/advanced-mode.cpp
@@ -72,12 +72,15 @@ void SuperSonic_Actions(EntityData1* data, motionwk* mwp, CharObj2* co2)
         case Act_SuperSonic_Jump:
             data->Action = Act_Sonic_Jump;
             break;
-        case Act_Sonic_JumpPanel: // sadx is bad
-            data->Action = Act_Sonic_Fall;
-            NullifyVelocity((EntityData2*)mwp, co2);
-            PrintDebug("[SuperSonic] Invalid action \"Act_Sonic_JumpPanel\" cancelled.\n");
-
+        case Act_Sonic_JumpPanel:
+            if (++data->field_A == 100) { //fail safe: fix super sonic stuck infinitely after the last panel.
+                data->Action = Act_Sonic_Fall;
+                data->field_A = 0;
+            }
             break;
+        case Act_Sonic_JumpPanelOn:
+               data->field_A = 0;
+               break;
         }
     }
 }

--- a/sadx-super-sonic/objects.cpp
+++ b/sadx-super-sonic/objects.cpp
@@ -17,7 +17,7 @@ static void LoadSonicDashTrail_r(EntityData1* player)
 	{
 		obj = LoadObject(LoadObj_Data1, 6, SonicDashTrail_Init);
 	}
-	
+
 	if (obj)
 	{
 		obj->Data1->CharIndex = player->CharIndex;
@@ -37,7 +37,7 @@ static void LoadSonicDashEffect_r(EntityData1* player)
 	{
 		obj = LoadObject(LoadObj_Data1, 5, (ObjectFuncPtr)0x4A2A40);
 	}
-	
+
 	if (obj)
 	{
 		obj->Data1->CharIndex = player->CharIndex;
@@ -89,4 +89,11 @@ void Objects_Init()
 	}
 
 	WriteJump(Sonic_SuperAura_Load, Sonic_SuperAura_Load_r);
+
+	//move Jump Panel collision pos y from 1.5 to 4.0 (Fix Super Sonic stuck/missing jump panel)
+	WriteData<1>((int*)0x97dfa7, 0x40);
+	WriteData<1>((int*)0x97dfa6, 0x80);
+	//same
+	WriteData<1>((int*)0x97dfd7, 0x40);
+	WriteData<1>((int*)0x97dfd6, 0x80);
 }

--- a/sadx-super-sonic/physics.cpp
+++ b/sadx-super-sonic/physics.cpp
@@ -65,7 +65,7 @@ static void __cdecl Sonic_SuperPhysicsLevel_Main(task* tsk)
 
 static void __cdecl Sonic_SuperPhysics_Load_r(task* tsk)
 {
-	if (LastStoryFlag == true)
+	if (LastStoryFlag == true || CurrentLevel == LevelIDs_PerfectChaos && CurrentAct == 0)
 	{
 		TARGET_DYNAMIC(Sonic_SuperPhysics_Load)(tsk);
 

--- a/sadx-super-sonic/supersonic.cpp
+++ b/sadx-super-sonic/supersonic.cpp
@@ -159,7 +159,7 @@ static void Sonic_Exec_r(task* tsk)
 	motionwk* mwp = tsk->mwp;
 	CharObj2* co2 = (CharObj2*)mwp->work.ptr;
 
-	if (LastStoryFlag == false && MetalSonicFlag == false)
+	if (LastStoryFlag == false && MetalSonicFlag == false && CurrentLevel != LevelIDs_PerfectChaos)
 	{
 		if (data->Action == Act_Sonic_Init)
 		{


### PR DESCRIPTION
Moving the collision of the jump panel did the trick, still work fine as Sonic too. 
Also fix the super sonic stuck infinitely instead of landing (a bit ugly, might be a better way to do this.)

Tested in Windy Valley, Ice Cap and Red Mountain, all of them worked fine, w/ test spawn with debug and release.